### PR TITLE
[#9] 테스트 커버리지 측정 CI 구축

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -29,10 +29,10 @@ jobs:
         run: ./gradlew build jacocoTestReport
 
       - name: Codecov
-          uses: codecov/codecov-action@v3.1.0
-          with:
-            token: ${{ secrets.CODECOV_TOKEN }}
-            file: ./backend/build/reports/jacoco/test/jacocoTestReport.xml
+        uses: codecov/codecov-action@v3.1.0
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          file: ./backend/build/reports/jacoco/test/jacocoTestReport.xml
           
       - name: Publish Unit Test Results
         uses: EnricoMi/publish-unit-test-result-action@v1

--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -26,7 +26,13 @@ jobs:
 
       - name: Test with Gradle
         working-directory: ./backend
-        run: ./gradlew build
+        run: ./gradlew build jacocoTestReport
+
+      - name: Codecov
+          uses: codecov/codecov-action@v3.1.0
+          with:
+            token: ${{ secrets.CODECOV_TOKEN }}
+            file: ./backend/build/reports/jacoco/test/jacocoTestReport.xml
           
       - name: Publish Unit Test Results
         uses: EnricoMi/publish-unit-test-result-action@v1

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -2,6 +2,7 @@ plugins {
 	id 'org.springframework.boot' version '2.7.4'
 	id 'io.spring.dependency-management' version '1.0.14.RELEASE'
 	id 'java'
+	id 'jacoco'
 }
 
 group = 'com.huemap'
@@ -18,6 +19,10 @@ repositories {
 	mavenCentral()
 }
 
+jacoco {
+	toolVersion = '0.8.8'
+}
+
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
@@ -30,4 +35,15 @@ dependencies {
 
 tasks.named('test') {
 	useJUnitPlatform()
+	finalizedBy jacocoTestReport
+}
+
+jacocoTestReport {
+	executionData(fileTree(project.rootDir.absolutePath).include("**/build/jacoco/*.exec"))
+
+	reports {
+		html.enabled true
+		xml.enabled true
+		csv.enabled false
+	}
 }

--- a/backend/codecov.yml
+++ b/backend/codecov.yml
@@ -1,0 +1,9 @@
+codecov:
+  require_ci_to_pass: yes
+
+comment:
+  layout: "reach,diff,flags,files,footer"
+  behavior: default
+  require_changes: false
+  branches:
+    - main

--- a/backend/src/test/java/com/huemap/backend/CiTest.java
+++ b/backend/src/test/java/com/huemap/backend/CiTest.java
@@ -1,0 +1,14 @@
+package com.huemap.backend;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.util.Assert;
+
+@SpringBootTest
+public class CiTest {
+
+  @Test
+  void randomTest() {
+    Assert.isTrue(true, "test");
+  }
+}


### PR DESCRIPTION
https://www.notion.so/Github-Actions-CI-0b90e3bde6ac408ebe6b2d08864a5015
빌드 및 테스트 자동화, 테스트 커버리지 측정 CI에 대한 정리글입니다.

테스트 커버리지 측정 도구는 jacoco를 사용했고, 테스트 커버리지관리는 codecov를 사용했습니다.