### PR TITLE
[#16] Flask 개발 환경 구축

### DIFF
--- a/backend/src/main/java/com/huemap/backend/common/presentation/HealthCheckController.java
+++ b/backend/src/main/java/com/huemap/backend/common/presentation/HealthCheckController.java
@@ -5,7 +5,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-@RequestMapping("/healthCheck")
+@RequestMapping("/api/healthCheck")
 public class HealthCheckController {
 
     @GetMapping

--- a/data/Dockerfile
+++ b/data/Dockerfile
@@ -1,0 +1,11 @@
+FROM python:3
+
+WORKDIR /app
+
+ADD . /app
+RUN python3 -m pip install -U pip
+RUN pip3 install flask
+RUN pip3 install uwsgi
+
+
+CMD ["uwsgi","uwsgi.ini"]

--- a/data/app.py
+++ b/data/app.py
@@ -1,0 +1,9 @@
+from flask import Flask
+from route.app_route import app_route
+
+app = Flask(__name__)
+
+app.register_blueprint(app_route)
+
+if __name__ == '__main__':
+    app.run(host='0.0.0.0')

--- a/data/route/app_route.py
+++ b/data/route/app_route.py
@@ -1,0 +1,7 @@
+from flask import Blueprint, render_template
+
+app_route = Blueprint('first_route',__name__)
+
+@app_route.route('/data/healthCheck',methods = ['GET'])
+def index():
+    return "휴맵 플라스크 서버"

--- a/data/uwsgi.ini
+++ b/data/uwsgi.ini
@@ -1,0 +1,10 @@
+[uwsgi]
+wsgi-file = app.py
+callable = app
+socket = :5050
+processes = 4
+threads = 2
+master = true
+vacum = true
+chmod-socket = 660
+die-on-term = true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,7 @@ version: '3'
 services:
 
   nginx:
+    restart: always
     container_name: nginx
     build:
       context: ./nginx
@@ -14,8 +15,10 @@ services:
       - ./nginx/conf.d:/etc/nginx/conf.d
     depends_on:
       - backend_spring
+      - backend_flask
 
   database:
+    restart: always
     container_name: mysql
     image: mysql/mysql-server:5.7
     environment:
@@ -32,6 +35,7 @@ services:
 
 
   backend_spring:
+    restart: always
     container_name: backend_spring
     build:
       context: ./backend
@@ -42,6 +46,17 @@ services:
       SPRING_DATASOURCE_URL: jdbc:mysql://mysql:3306/huemap?useSSL=false
       SPRING_DATASOURCE_USERNAME: "root"
       SPRING_DATASOURCE_PASSWORD: "1234"
+    depends_on:
+      - database
+
+  backend_flask:
+    restart: always
+    container_name: backend_flask
+    build:
+      context: ./data
+      dockerfile: Dockerfile
+    expose:
+      - 5050
     depends_on:
       - database
 

--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -1,5 +1,6 @@
 FROM nginx:stable-alpine
 
+COPY ./index.html /etc/nginx/html/index.html
 COPY ./conf.d/app.conf /etc/nginx/conf.d/default.conf
 
 EXPOSE 80

--- a/nginx/conf.d/app.conf
+++ b/nginx/conf.d/app.conf
@@ -2,15 +2,26 @@ upstream backend_spring {
     server backend_spring:8080;
 }
 
+upstream backend_flask {
+    server backend_flask:5050;
+}
+
+
 server {
     listen 80;
     access_log off;
 
-    location / {
+    location /api {
         proxy_pass http://backend_spring;
         proxy_set_header Host $host:$server_port;
         proxy_set_header X-Forwarded-Host $server_name;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
     }
+
+    location /data {
+        include uwsgi_params;
+        uwsgi_pass backend_flask;
+    }
+
 }

--- a/nginx/index.html
+++ b/nginx/index.html
@@ -1,0 +1,5 @@
+<html>
+    <body>
+        welcome huemap
+    </body>
+</html>


### PR DESCRIPTION
Falsk 서버 용 폴더 data생성 및 도커 설정 파일 수정
aws ec2 환경에서 flask 서버 구동 확인
 
![3](https://user-images.githubusercontent.com/79401359/195495399-e48cb5ea-ff85-437f-8a05-56b1515a40e9.png)

nginx가 제대로 돌아가는지 확인하기 위해 기본 html을 설정해줌

![1](https://user-images.githubusercontent.com/79401359/195495349-3affc4ed-9f35-4c9b-82de-98ac5f672f31.png)

요청 앞에 /api가 붙은 요청은 스프링 서버로, /data가 붙은 요청은 flask 서버로 전송되도록 하기 위해 기존 nginx 설정파일에서 스프링 서버를 location /에서 location /api로 변경함 그에따라 healthCheck url도 앞에 /api를 붙임 

![2](https://user-images.githubusercontent.com/79401359/195495666-f143509d-fbf8-47e8-97ed-11b8142fd58b.png)
