### PR TITLE
[#53] MapStruct 라이브러리 dependency 추가

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -28,10 +28,17 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'mysql:mysql-connector-java'
+
+	implementation 'org.mapstruct:mapstruct:1.4.2.Final'
+	annotationProcessor "org.mapstruct:mapstruct-processor:1.4.2.Final"
+	annotationProcessor 'org.projectlombok:lombok-mapstruct-binding:0.1.0'
+
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.h2database:h2'
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+	testCompileOnly 'org.projectlombok:lombok'
+	testAnnotationProcessor 'org.projectlombok:lombok'
 }
 
 tasks.named('test') {

--- a/backend/src/main/java/com/huemap/backend/user/domain/UserMapper.java
+++ b/backend/src/main/java/com/huemap/backend/user/domain/UserMapper.java
@@ -1,0 +1,16 @@
+package com.huemap.backend.user.domain;
+
+import org.mapstruct.*;
+import org.mapstruct.ReportingPolicy;
+import org.mapstruct.factory.Mappers;
+
+@Mapper(
+    componentModel = "spring",
+    injectionStrategy = InjectionStrategy.CONSTRUCTOR,
+    unmappedTargetPolicy = ReportingPolicy.ERROR
+)
+public interface UserMapper {
+
+  UserMapper INSTANCE = Mappers.getMapper(UserMapper.class);
+
+}


### PR DESCRIPTION
* DTO <-> Entity 변환을 도와주는 MapStruct 라이브러리 dependency 추가
* UserMapper 클래스를 통해 Mapper 클래스 템플릿을 생성하였습니다.
* 아래는 매핑 테스트 결과입니다.
<img width="335" alt="스크린샷 2022-10-28 16 44 12" src="https://user-images.githubusercontent.com/78195316/198533447-9898f65a-adbb-4a4a-a201-d4599f55f8a0.png">
<img width="464" alt="스크린샷 2022-10-28 16 44 07" src="https://user-images.githubusercontent.com/78195316/198533453-7d5f2212-072e-4997-82f2-165f74593950.png">
프로젝트 빌드를 한 후 MapperImpl 클래스가 생성된 것을 확인할 수 있었습니다.
