### PR TITLE
[#66] 잘못된 폐쇄 제보 엔티티 & delete 필드 추가에 따른 bin 엔티티 수정

### DIFF
--- a/backend/src/main/java/com/huemap/backend/bin/domain/Bin.java
+++ b/backend/src/main/java/com/huemap/backend/bin/domain/Bin.java
@@ -6,6 +6,8 @@ import javax.persistence.Enumerated;
 import javax.persistence.Table;
 import javax.validation.constraints.NotNull;
 
+import org.hibernate.annotations.Where;
+
 import com.huemap.backend.common.entity.BaseEntity;
 
 import lombok.AccessLevel;
@@ -16,6 +18,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
 @Table
+@Where(clause = "deleted=false")
 public class Bin extends BaseEntity {
 
 	@NotNull
@@ -34,5 +37,7 @@ public class Bin extends BaseEntity {
 
 	@Enumerated(EnumType.STRING)
 	private BinType type;
+
+	private boolean deleted;
 
 }

--- a/backend/src/main/java/com/huemap/backend/report/domain/Closure.java
+++ b/backend/src/main/java/com/huemap/backend/report/domain/Closure.java
@@ -1,0 +1,34 @@
+package com.huemap.backend.report.domain;
+
+import javax.persistence.DiscriminatorValue;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+
+import com.huemap.backend.bin.domain.Bin;
+import com.huemap.backend.user.domain.User;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
+
+@Entity
+@DiscriminatorValue("CLOSURE")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Closure extends Report {
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "bin_id")
+  private Bin bin;
+
+  private int count;
+
+  private boolean deleted;
+
+  @Builder
+  public Closure(final User user, final Bin bin) {
+    super(user);
+    this.bin = bin;
+  }
+}

--- a/backend/src/main/java/com/huemap/backend/report/domain/Report.java
+++ b/backend/src/main/java/com/huemap/backend/report/domain/Report.java
@@ -1,0 +1,30 @@
+package com.huemap.backend.report.domain;
+
+import javax.persistence.DiscriminatorColumn;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.Inheritance;
+import javax.persistence.InheritanceType;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+
+import com.huemap.backend.common.entity.BaseEntity;
+import com.huemap.backend.user.domain.User;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Inheritance(strategy = InheritanceType.JOINED)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@DiscriminatorColumn(name = "type")
+public abstract class Report extends BaseEntity {
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "user_id")
+  private User user;
+
+  protected Report(final User user) {
+    this.user = user;
+  }
+}

--- a/backend/src/main/java/com/huemap/backend/user/domain/User.java
+++ b/backend/src/main/java/com/huemap/backend/user/domain/User.java
@@ -11,7 +11,7 @@ import com.huemap.backend.common.entity.BaseEntity;
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
-@Table
+@Table(name = "`user`")
 public class User extends BaseEntity {
 
   @Column


### PR DESCRIPTION
* 조인 전략을 사용하여 report 엔티티와 closure 엔티티 구현
* delete 필드 추가에 따른 bin 엔티티 애노테이션 추가
  * 엔티티를 조회하는 모든 쿼리에 where 조건을 추가해주는 기능 
* user 엔티티 table 애노테이션 추가
  * user가 예약어로 설정되어 있어서 테스트할 때 제대로 작동안하는 것으로 알고있어 추가하게 되었습니다.