### PR TITLE
[#68] 폐쇄 폐수거함 제보 service, repository 구현 & 단위 테스트 구현

### DIFF
--- a/backend/src/main/java/com/huemap/backend/common/exception/InvalidValueException.java
+++ b/backend/src/main/java/com/huemap/backend/common/exception/InvalidValueException.java
@@ -1,0 +1,10 @@
+package com.huemap.backend.common.exception;
+
+import com.huemap.backend.common.response.error.ErrorCode;
+
+public class InvalidValueException extends BusinessException {
+
+  public InvalidValueException(ErrorCode errorCode) {
+    super(errorCode);
+  }
+}

--- a/backend/src/main/java/com/huemap/backend/common/response/error/ErrorCode.java
+++ b/backend/src/main/java/com/huemap/backend/common/response/error/ErrorCode.java
@@ -8,7 +8,9 @@ import lombok.Getter;
 public enum ErrorCode {
 	INVALID_INPUT_VALUE(400, "적절하지 않은 요청 값입니다."),
 	INTERNAL_SERVER_ERROR(500, "서버 내부에 오류가 생겼습니다."),
-	BIN_NOT_FOUND(400, "폐수거함을 찾을 수 없습니다.");
+	BIN_NOT_FOUND(400, "폐수거함을 찾을 수 없습니다."),
+	REPORT_DISTANCE_FAR(400, "제보하려는 대상과 사용자의 거리가 너무 멉니다."),
+	CLOSURE_DUPLICATED(400, "중복된 폐수거함 폐쇄 제보를 할 수 없습니다.");
 
 	private final int status;
 	private final String message;

--- a/backend/src/main/java/com/huemap/backend/common/utils/GeometryUtil.java
+++ b/backend/src/main/java/com/huemap/backend/common/utils/GeometryUtil.java
@@ -1,0 +1,28 @@
+package com.huemap.backend.common.utils;
+
+public class GeometryUtil {
+
+  public static double calculateDistance(Double latitude1,
+                                         Double longitude1,
+                                         Double latitude2,
+                                         Double longitude2) {
+    final double theta = longitude1 - longitude2;
+    double dist = Math.sin(degToRad(latitude1)) * Math.sin(degToRad(latitude2))
+        + Math.cos(degToRad(latitude1)) * Math.cos(degToRad(latitude2)) * Math.cos(degToRad(theta));
+
+    dist = Math.acos(dist);
+    dist = radToDeg(dist);
+    dist = dist * 60 * 1.1515;
+    dist = dist * 1609.344;
+
+    return (dist);
+  }
+
+  private static double degToRad(double deg) {
+    return (deg * Math.PI / 180.0);
+  }
+
+  private static double radToDeg(double rad) {
+    return (rad * 180 / Math.PI);
+  }
+}

--- a/backend/src/main/java/com/huemap/backend/report/application/ReportService.java
+++ b/backend/src/main/java/com/huemap/backend/report/application/ReportService.java
@@ -1,15 +1,59 @@
 package com.huemap.backend.report.application;
 
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
+import com.huemap.backend.bin.domain.Bin;
+import com.huemap.backend.bin.domain.BinRepository;
+import com.huemap.backend.common.exception.EntityNotFoundException;
+import com.huemap.backend.common.exception.InvalidValueException;
+import com.huemap.backend.common.response.error.ErrorCode;
+import com.huemap.backend.common.utils.GeometryUtil;
+import com.huemap.backend.report.domain.Closure;
+import com.huemap.backend.report.domain.ReportRepository;
+import com.huemap.backend.report.domain.mapper.ClosureMapper;
 import com.huemap.backend.report.dto.request.ClosureCreateRequest;
 import com.huemap.backend.report.dto.response.ClosureCreateResponse;
 
+import lombok.RequiredArgsConstructor;
+
 @Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
 public class ReportService {
+
+  private final ReportRepository reportRepository;
+  private final BinRepository binRepository;
+
+  private final double DISTANCE_METER = 10;
+
+  @Transactional
   public ClosureCreateResponse saveClosure(Long userId,
                                            Long binId,
                                            ClosureCreateRequest closureCreateRequest) {
-    return null;
+
+    final Bin bin = binRepository.findById(binId)
+                                 .orElseThrow(
+                                     () -> new EntityNotFoundException(ErrorCode.BIN_NOT_FOUND));
+
+    validateDistanceBetweenUserAndBin(bin, closureCreateRequest.getLatitude(),
+                                      closureCreateRequest.getLongitude());
+    validateAlreadyExist(userId, bin);
+
+    final Closure closure = (Closure)reportRepository.save(ClosureMapper.INSTANCE.toEntity(userId, bin));
+
+    return ClosureMapper.INSTANCE.toDto(closure);
+  }
+
+  private void validateAlreadyExist(Long userId, Bin bin) {
+    reportRepository.findByUserIdAndBin(userId, bin)
+                    .ifPresent(c -> {throw new InvalidValueException(ErrorCode.CLOSURE_DUPLICATED);});
+  }
+
+  private void validateDistanceBetweenUserAndBin(Bin bin, Double userLatitude, Double userLongitude) {
+    if (GeometryUtil.calculateDistance(bin.getLocation().getX(), bin.getLocation().getY(),
+                                       userLatitude, userLongitude) > DISTANCE_METER) {
+      throw new InvalidValueException(ErrorCode.REPORT_DISTANCE_FAR);
+    }
   }
 }

--- a/backend/src/main/java/com/huemap/backend/report/domain/Closure.java
+++ b/backend/src/main/java/com/huemap/backend/report/domain/Closure.java
@@ -7,7 +7,6 @@ import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
 
 import com.huemap.backend.bin.domain.Bin;
-import com.huemap.backend.user.domain.User;
 
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -22,13 +21,9 @@ public class Closure extends Report {
   @JoinColumn(name = "bin_id")
   private Bin bin;
 
-  private int count;
-
-  private boolean deleted;
-
   @Builder
-  public Closure(final User user, final Bin bin) {
-    super(user);
+  public Closure(final Long userId, final Bin bin) {
+    super(userId);
     this.bin = bin;
   }
 }

--- a/backend/src/main/java/com/huemap/backend/report/domain/Report.java
+++ b/backend/src/main/java/com/huemap/backend/report/domain/Report.java
@@ -2,14 +2,11 @@ package com.huemap.backend.report.domain;
 
 import javax.persistence.DiscriminatorColumn;
 import javax.persistence.Entity;
-import javax.persistence.FetchType;
 import javax.persistence.Inheritance;
 import javax.persistence.InheritanceType;
-import javax.persistence.JoinColumn;
-import javax.persistence.ManyToOne;
+import javax.validation.constraints.NotNull;
 
 import com.huemap.backend.common.entity.BaseEntity;
-import com.huemap.backend.user.domain.User;
 
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
@@ -20,11 +17,10 @@ import lombok.NoArgsConstructor;
 @DiscriminatorColumn(name = "type")
 public abstract class Report extends BaseEntity {
 
-  @ManyToOne(fetch = FetchType.LAZY)
-  @JoinColumn(name = "user_id")
-  private User user;
+  @NotNull
+  private Long userId;
 
-  protected Report(final User user) {
-    this.user = user;
+  protected Report(final Long userId) {
+    this.userId = userId;
   }
 }

--- a/backend/src/main/java/com/huemap/backend/report/domain/ReportRepository.java
+++ b/backend/src/main/java/com/huemap/backend/report/domain/ReportRepository.java
@@ -1,0 +1,12 @@
+package com.huemap.backend.report.domain;
+
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.huemap.backend.bin.domain.Bin;
+
+public interface ReportRepository<T extends Report> extends JpaRepository<T, Long> {
+
+  Optional<Closure> findByUserIdAndBin(Long userId, Bin bin);
+}

--- a/backend/src/main/java/com/huemap/backend/report/domain/mapper/ClosureMapper.java
+++ b/backend/src/main/java/com/huemap/backend/report/domain/mapper/ClosureMapper.java
@@ -5,6 +5,7 @@ import org.mapstruct.Mapper;
 import org.mapstruct.ReportingPolicy;
 import org.mapstruct.factory.Mappers;
 
+import com.huemap.backend.bin.domain.Bin;
 import com.huemap.backend.report.domain.Closure;
 import com.huemap.backend.report.dto.response.ClosureCreateResponse;
 
@@ -14,7 +15,9 @@ import com.huemap.backend.report.dto.response.ClosureCreateResponse;
     unmappedTargetPolicy = ReportingPolicy.ERROR
 )
 public interface ClosureMapper {
-  Mappers INSTANCE = Mappers.getMapper(Mappers.class);
+  ClosureMapper INSTANCE = Mappers.getMapper(ClosureMapper.class);
+
+  Closure toEntity(Long userId, Bin bin);
 
   ClosureCreateResponse toDto(Closure closure);
 

--- a/backend/src/test/java/com/huemap/backend/common/TestUtils.java
+++ b/backend/src/test/java/com/huemap/backend/common/TestUtils.java
@@ -1,0 +1,44 @@
+package com.huemap.backend.common;
+
+import java.lang.reflect.Constructor;
+
+import org.locationtech.jts.geom.Point;
+import org.locationtech.jts.io.WKTReader;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import com.huemap.backend.bin.domain.Bin;
+import com.huemap.backend.bin.domain.BinType;
+import com.huemap.backend.report.domain.Closure;
+
+public class TestUtils {
+  public static Bin getBin() throws Exception {
+    Class<?> clazz = Class.forName("com.huemap.backend.bin.domain.Bin");
+    Constructor<?> constructor = clazz.getDeclaredConstructor();
+    constructor.setAccessible(true);
+    Bin bin = (Bin)constructor.newInstance();
+
+    String pointWKT = String.format("POINT(%s %s)", 37.5833354, 126.9876779);
+    Point point = (Point) new WKTReader().read(pointWKT);
+
+    ReflectionTestUtils.setField(bin, "id", 1L);
+    ReflectionTestUtils.setField(bin, "gu", "종로구");
+    ReflectionTestUtils.setField(bin, "location", point);
+    ReflectionTestUtils.setField(bin, "address", "서울특별시 종로구 창덕궁7길 5");
+    ReflectionTestUtils.setField(bin, "addressDescription", null);
+    ReflectionTestUtils.setField(bin, "type", BinType.CLOTHES);
+    ReflectionTestUtils.setField(bin, "deleted", false);
+
+    return bin;
+  }
+
+  public static Closure getClosure(Bin bin) {
+    Closure closure = Closure.builder()
+                             .userId(1L)
+                             .bin(bin)
+                             .build();
+
+    ReflectionTestUtils.setField(bin, "id", 1L);
+
+    return closure;
+  }
+}

--- a/backend/src/test/java/com/huemap/backend/report/application/ReportServiceTest.java
+++ b/backend/src/test/java/com/huemap/backend/report/application/ReportServiceTest.java
@@ -1,0 +1,133 @@
+package com.huemap.backend.report.application;
+
+import static com.huemap.backend.common.TestUtils.*;
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.*;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.huemap.backend.bin.domain.Bin;
+import com.huemap.backend.bin.domain.BinRepository;
+import com.huemap.backend.common.exception.EntityNotFoundException;
+import com.huemap.backend.common.exception.InvalidValueException;
+import com.huemap.backend.common.response.error.ErrorCode;
+import com.huemap.backend.report.domain.Closure;
+import com.huemap.backend.report.domain.ReportRepository;
+import com.huemap.backend.report.dto.request.ClosureCreateRequest;
+import com.huemap.backend.report.dto.response.ClosureCreateResponse;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("ReportService의")
+public class ReportServiceTest {
+
+  @InjectMocks
+  private ReportService reportService;
+
+  @Mock
+  private ReportRepository reportRepository;
+
+  @Mock
+  private BinRepository binRepository;
+
+  @Nested
+  @DisplayName("saveClosure 메소드는")
+  class saveClosure {
+
+    @Nested
+    @DisplayName("폐수거함이 존재하지 않는 경우")
+    class Context_with_not_found_bin {
+
+      @Test
+      @DisplayName("예외를 던진다.")
+      void It_throws_exception() {
+        //given
+        final ClosureCreateRequest request = new ClosureCreateRequest(37.583297, 126.987755);
+        given(binRepository.findById(anyLong())).willReturn(Optional.empty());
+
+        // when, then
+        assertThatThrownBy(
+            () -> reportService.saveClosure(1L, 1L, request))
+            .isInstanceOf(EntityNotFoundException.class)
+            .extracting("errorCode")
+            .isEqualTo(ErrorCode.BIN_NOT_FOUND);
+      }
+    }
+
+    @Nested
+    @DisplayName("폐쇄 제보하려는 위치와 폐수거함의 거리 차이가 10m 이상이면")
+    class Context_with_distance_far_bin {
+
+      @Test
+      @DisplayName("예외를 던진다.")
+      void It_throws_exception() throws Exception {
+        //given
+        final ClosureCreateRequest request = new ClosureCreateRequest(37.583289, 126.987803);
+        final Bin bin = getBin();
+        given(binRepository.findById(anyLong())).willReturn(Optional.of(bin));
+
+        // when, then
+        assertThatThrownBy(
+            () -> reportService.saveClosure(1L, 1L, request))
+            .isInstanceOf(InvalidValueException.class)
+            .extracting("errorCode")
+            .isEqualTo(ErrorCode.REPORT_DISTANCE_FAR);
+      }
+    }
+
+    @Nested
+    @DisplayName("이미 같은 폐수거함을 폐쇄 제보한 상태에서 폐쇄 제보를 한다면")
+    class Context_with_already_exist_closure {
+
+      @Test
+      @DisplayName("예외를 던진다.")
+      void It_throws_exception() throws Exception {
+        //given
+        final ClosureCreateRequest request = new ClosureCreateRequest(37.583297, 126.987755);
+        final Bin bin = getBin();
+        final Closure closure = getClosure(bin);
+        given(binRepository.findById(anyLong())).willReturn(Optional.of(bin));
+        given(reportRepository.findByUserIdAndBin(anyLong(), any(Bin.class))).willReturn(Optional.of(closure));
+
+        // when, then
+        assertThatThrownBy(
+            () -> reportService.saveClosure(1L, 1L, request))
+            .isInstanceOf(InvalidValueException.class)
+            .extracting("errorCode")
+            .isEqualTo(ErrorCode.CLOSURE_DUPLICATED);
+      }
+    }
+
+    @Nested
+    @DisplayName("이미 같은 폐수거함을 폐쇄 제보한 상태에서 폐쇄 제보를 한다면")
+    class Context_with_valid_argument {
+
+      @Test
+      @DisplayName("폐쇄 제보를 저장한다.")
+      void success() throws Exception {
+        //given
+        final ClosureCreateRequest request = new ClosureCreateRequest(37.583297, 126.987755);
+        final Bin bin = getBin();
+        final Closure closure = getClosure(bin);
+        given(binRepository.findById(anyLong())).willReturn(Optional.of(bin));
+        given(reportRepository.findByUserIdAndBin(anyLong(), any(Bin.class))).willReturn(Optional.empty());
+        given(reportRepository.save(any(Closure.class))).willReturn(closure);
+
+        // when
+        final ClosureCreateResponse response = reportService.saveClosure(1L, 1L, request);
+
+        //then
+        verify(reportRepository).save(any(Closure.class));
+        assertThat(response.getId()).isEqualTo(closure.getId());
+      }
+    }
+  }
+}

--- a/backend/src/test/java/com/huemap/backend/report/domain/ReportRepositoryTest.java
+++ b/backend/src/test/java/com/huemap/backend/report/domain/ReportRepositoryTest.java
@@ -1,0 +1,52 @@
+package com.huemap.backend.report.domain;
+
+import static com.huemap.backend.common.TestUtils.*;
+import static org.assertj.core.api.Assertions.*;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+import com.huemap.backend.bin.domain.Bin;
+import com.huemap.backend.bin.domain.BinRepository;
+
+@DataJpaTest
+@DisplayName("ReportRepository의")
+public class ReportRepositoryTest {
+
+  @Autowired
+  private ReportRepository reportRepository;
+
+  @Autowired
+  private BinRepository binRepository;
+
+  @Nested
+  @DisplayName("findByUserIdAndBin 메소드는")
+  class findByUserIdAndBin {
+
+    @Nested
+    @DisplayName("유저 id와 Bin 객체를 입력 받으면")
+    class Context_with_userId_bin {
+
+      @Test
+      @DisplayName("이에 해당하는 Closure 엔티티를 반환한다.")
+      void It_returns_closure() throws Exception {
+        //given
+        final Long userId = 1L;
+        final Bin bin = binRepository.save(getBin());
+        final Closure expected = (Closure)reportRepository.save(getClosure(bin));
+
+        //when
+        final Optional<Closure> actual = reportRepository.findByUserIdAndBin(userId, bin);
+
+        //then
+        assertThat(actual).isNotEmpty();
+        assertThat(actual.get()).isEqualTo(expected);
+      }
+    }
+  }
+}

--- a/backend/src/test/resources/application.yml
+++ b/backend/src/test/resources/application.yml
@@ -1,0 +1,14 @@
+spring:
+  datasource:
+    url: jdbc:h2:mem:testdb;MODE=MYSQL
+    username: sa
+    password:
+    driver-class-name: org.h2.Driver
+  jpa:
+    database: H2
+    show-sql: true
+    properties:
+      hibernate:
+        format_sql: true
+        ddl-auto: create
+        dialect: org.hibernate.spatial.dialect.h2geodb.GeoDBDialect


### PR DESCRIPTION
* Report, Closure 엔티티 필드 수정
  * deleted, count 필드 제거
    * 유저 한 명당 해당 폐수거함에 대한 폐쇄 제보를 하나씩만 하는 것이 서비스상 나아보여서 필드를 제거하였습니다.
    * 그렇게 되면 폐쇄 제보가 3개 이상 쌓였을 때 폐수거함을 제거하는 로직은 스케줄러를 사용해서 하루에 한 번씩만 수행하는 것으로 변경하겠습니다. 그 이유는 폐쇄 제보에 대한 count 조회 쿼리가 제보 요청마다 날라가야하는데, 불필요한 작업으로 보여 스케줄러를 도입할 예정입니다. 이는 다음 PR에 올리도록 하겠습니다.
 * User `@ManyToOne` 매핑 제거
   * report에 대한 작업 수행시 user 엔티티를 영속성 컨텍스트에 올려서 관리할 필요가 없다고 생각하여 user_id로만 연결시켰습니다.
*  GeometryUtil 클래스 구현
  * 위치 데이터를 다루는 로직을 담은 클래스를 구현하였습니다.
* 단위 테스트
  * yml 파일 생성
    * repository 테스트를 위한 h2 데이터베이스를 띄우기 위해 설정 파일을 작성하였는데, geometry 타입을 지원하는 h2 dialect로 설정하였습니다. https://stackoverflow.com/questions/44261899/geometry-datatype-in-h2-w-spring-jpa
  * TestUtils 클래스 생성
    * 단위 테스트에 사용될 엔티티들을 생성할 수 있는 메소드들을 담았습니다.
    * 중복 방지      
 


![스크린샷 2022-11-03 10 18 10](https://user-images.githubusercontent.com/78195316/199630812-7fc2bd55-2f71-4197-93bf-b8fd929567d5.png)
