### PR TITLE
[#86] 일정 수 이상 폐쇄 제보 받은 폐수거함 제거 스케줄러 구현

### DIFF
--- a/backend/src/main/java/com/huemap/backend/BackendApplication.java
+++ b/backend/src/main/java/com/huemap/backend/BackendApplication.java
@@ -3,8 +3,10 @@ package com.huemap.backend;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @EnableJpaAuditing
+@EnableScheduling
 @SpringBootApplication
 public class BackendApplication {
 

--- a/backend/src/main/java/com/huemap/backend/bin/domain/Bin.java
+++ b/backend/src/main/java/com/huemap/backend/bin/domain/Bin.java
@@ -39,4 +39,7 @@ public class Bin extends BaseEntity {
 
 	private boolean deleted;
 
+	public void delete() {
+		this.deleted = true;
+	}
 }

--- a/backend/src/main/java/com/huemap/backend/bin/domain/BinRepository.java
+++ b/backend/src/main/java/com/huemap/backend/bin/domain/BinRepository.java
@@ -3,8 +3,18 @@ package com.huemap.backend.bin.domain;
 import java.util.List;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
-public interface BinRepository extends JpaRepository<Bin,Long> {
+public interface BinRepository extends JpaRepository<Bin, Long> {
+
 	List<Bin> findAllByType(BinType type);
 
+	@Query("SELECT b "
+			+ "FROM Bin b "
+			+ "WHERE b.id IN "
+			+ "(SELECT c.bin.id "
+			+ "FROM Closure c "
+			+ "GROUP BY c.bin "
+			+ "HAVING COUNT(c.bin) >= :closureCount)")
+	List<Bin> findAllHasClosureOver(long closureCount);
 }

--- a/backend/src/main/java/com/huemap/backend/common/config/SchedulerConfig.java
+++ b/backend/src/main/java/com/huemap/backend/common/config/SchedulerConfig.java
@@ -1,0 +1,23 @@
+package com.huemap.backend.common.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.SchedulingConfigurer;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
+import org.springframework.scheduling.config.ScheduledTaskRegistrar;
+
+@Configuration
+public class SchedulerConfig implements SchedulingConfigurer {
+
+  private static final int POOL_SIZE = 3;
+
+  @Override
+  public void configureTasks(ScheduledTaskRegistrar taskRegistrar) {
+    ThreadPoolTaskScheduler scheduler = new ThreadPoolTaskScheduler();
+
+    scheduler.setPoolSize(POOL_SIZE);
+    scheduler.setThreadNamePrefix("현재 쓰레드-");
+    scheduler.initialize();
+
+    taskRegistrar.setTaskScheduler(scheduler);
+  }
+}

--- a/backend/src/main/java/com/huemap/backend/common/scheduler/SchedulerService.java
+++ b/backend/src/main/java/com/huemap/backend/common/scheduler/SchedulerService.java
@@ -1,0 +1,34 @@
+package com.huemap.backend.common.scheduler;
+
+import java.time.LocalDateTime;
+
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.huemap.backend.bin.domain.Bin;
+import com.huemap.backend.bin.domain.BinRepository;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Transactional
+@RequiredArgsConstructor
+@Service
+public class SchedulerService {
+
+  private final BinRepository binRepository;
+
+  private final long CLOSURE_COUNT = 3L;
+
+  @Scheduled(cron = "0 0 0 * * *", zone = "Asia/Seoul")
+  @Transactional
+  public void deleteBinHasClosureOver() {
+    final LocalDateTime now = LocalDateTime.now();
+    log.info("{}, 폐쇄 폐수거함 제보가 {}개 이상이면 폐수거함을 제거하는 스케줄러 실행", now, CLOSURE_COUNT);
+
+    binRepository.findAllHasClosureOver(CLOSURE_COUNT)
+                 .forEach(Bin::delete);
+  }
+}

--- a/backend/src/test/java/com/huemap/backend/bin/domain/BinRepositoryTest.java
+++ b/backend/src/test/java/com/huemap/backend/bin/domain/BinRepositoryTest.java
@@ -1,0 +1,56 @@
+package com.huemap.backend.bin.domain;
+
+import static com.huemap.backend.common.TestUtils.*;
+import static org.assertj.core.api.Assertions.*;
+
+import java.lang.reflect.Constructor;
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.locationtech.jts.geom.Point;
+import org.locationtech.jts.io.WKTReader;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import com.huemap.backend.report.domain.Closure;
+import com.huemap.backend.report.domain.ReportRepository;
+
+@DataJpaTest
+@DisplayName("BinRepository의")
+public class BinRepositoryTest {
+
+  @Autowired
+  private BinRepository binRepository;
+
+  @Autowired
+  private ReportRepository reportRepository;
+
+  @Nested
+  @DisplayName("findAllHasClosureOver 메소드는")
+  class findAllHasClosureOver {
+
+    @Nested
+    @DisplayName("폐쇄 제보 기준 값을 입력받으면")
+    class Context_with_closure_count {
+
+      @Test
+      @DisplayName("해당 개수를 넘은 Bin 엔티티를 반환한다.")
+      void It_returns_closure() throws Exception {
+        //given
+        final long closureCount = 1L;
+        final Bin bin = binRepository.save(getBin());
+        reportRepository.save(getClosure(bin));
+
+        //when
+        final List<Bin> bins = binRepository.findAllHasClosureOver(closureCount);
+
+        //then
+        assertThat(bins.size()).isEqualTo(1);
+        assertThat(bins.get(0).getId()).isEqualTo(bin.getId());
+      }
+    }
+  }
+}

--- a/backend/src/test/java/com/huemap/backend/bin/domain/BinRepositoryTest.java
+++ b/backend/src/test/java/com/huemap/backend/bin/domain/BinRepositoryTest.java
@@ -3,19 +3,14 @@ package com.huemap.backend.bin.domain;
 import static com.huemap.backend.common.TestUtils.*;
 import static org.assertj.core.api.Assertions.*;
 
-import java.lang.reflect.Constructor;
 import java.util.List;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-import org.locationtech.jts.geom.Point;
-import org.locationtech.jts.io.WKTReader;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
-import org.springframework.test.util.ReflectionTestUtils;
 
-import com.huemap.backend.report.domain.Closure;
 import com.huemap.backend.report.domain.ReportRepository;
 
 @DataJpaTest

--- a/backend/src/test/java/com/huemap/backend/common/TestUtils.java
+++ b/backend/src/test/java/com/huemap/backend/common/TestUtils.java
@@ -20,7 +20,6 @@ public class TestUtils {
     String pointWKT = String.format("POINT(%s %s)", 37.5833354, 126.9876779);
     Point point = (Point) new WKTReader().read(pointWKT);
 
-    ReflectionTestUtils.setField(bin, "id", 1L);
     ReflectionTestUtils.setField(bin, "gu", "종로구");
     ReflectionTestUtils.setField(bin, "location", point);
     ReflectionTestUtils.setField(bin, "address", "서울특별시 종로구 창덕궁7길 5");
@@ -36,8 +35,6 @@ public class TestUtils {
                              .userId(1L)
                              .bin(bin)
                              .build();
-
-    ReflectionTestUtils.setField(bin, "id", 1L);
 
     return closure;
   }

--- a/backend/src/test/java/com/huemap/backend/common/scheduler/SchedulerServiceTest.java
+++ b/backend/src/test/java/com/huemap/backend/common/scheduler/SchedulerServiceTest.java
@@ -1,0 +1,49 @@
+package com.huemap.backend.common.scheduler;
+
+import static com.huemap.backend.common.TestUtils.*;
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.huemap.backend.bin.domain.Bin;
+import com.huemap.backend.bin.domain.BinRepository;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("SchedulerService의")
+public class SchedulerServiceTest {
+
+  @InjectMocks
+  private SchedulerService schedulerService;
+
+  @Mock
+  private BinRepository binRepository;
+
+  @Nested
+  @DisplayName("deleteBinHasClosureOver 메소드는")
+  class deleteBinHasClosureOver {
+
+    @Test
+    @DisplayName("폐쇄 제보가 일정 수 이상인 폐수거함을 제거한다.")
+    void It_throws_exception() throws Exception {
+      //given
+      final Bin bin = getBin();
+      given(binRepository.findAllHasClosureOver(anyLong())).willReturn(List.of(bin));
+
+      // when
+      schedulerService.deleteBinHasClosureOver();
+
+      // then
+      verify(binRepository).findAllHasClosureOver(anyLong());
+      assertThat(bin.isDeleted()).isTrue();
+    }
+  }
+}


### PR DESCRIPTION
* 매일 자정 00:00 시에 제거 스케줄러가 돌아가게끔 구현하였습니다.
* 제거를 진행하는 폐쇄 제보 기준 값은 `SchedulerService` 클래스의  `CLOSURE_COUNT `으로 변경 가능합니다.