### PR TITLE
[BE] 폐수거함 설치 건의 엔티티 정의

### DIFF
--- a/backend/src/main/java/com/huemap/backend/suggestion/domain/Suggestion.java
+++ b/backend/src/main/java/com/huemap/backend/suggestion/domain/Suggestion.java
@@ -1,0 +1,36 @@
+package com.huemap.backend.suggestion.domain;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
+import javax.persistence.Table;
+import javax.validation.constraints.NotNull;
+
+import org.locationtech.jts.geom.Point;
+
+import com.huemap.backend.bin.domain.BinType;
+import com.huemap.backend.common.entity.BaseEntity;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+@Table
+public class Suggestion extends BaseEntity {
+
+	@NotNull
+	private String gu;
+
+	@Column(columnDefinition = "GEOMETRY")
+	private Point location;
+
+	@Enumerated(EnumType.STRING)
+	private BinType type;
+
+	@NotNull
+	private Long userId;
+}


### PR DESCRIPTION
건의 데이터를 구별로 클러스터링 할 필요가 있어 보여 gu 필드도 추가하였습니다
report 엔티티 처럼 user 엔티티를 영속성 컨텍스트에 올려서 관리할 필요가 없다고 생각하여 user_id로만 연결시켰습니다.