### PR TITLE
[#99] Bin 엔티티 필드 추가 & Presence 엔티티 수정

### DIFF
--- a/backend/src/main/java/com/huemap/backend/bin/domain/Bin.java
+++ b/backend/src/main/java/com/huemap/backend/bin/domain/Bin.java
@@ -37,6 +37,8 @@ public class Bin extends BaseEntity {
 	@Enumerated(EnumType.STRING)
 	private BinType type;
 
+	private boolean isCandidate;
+
 	private boolean deleted;
 
 	public void delete() {

--- a/backend/src/main/java/com/huemap/backend/report/domain/Presence.java
+++ b/backend/src/main/java/com/huemap/backend/report/domain/Presence.java
@@ -1,16 +1,15 @@
 package com.huemap.backend.report.domain;
 
-import javax.persistence.Column;
 import javax.persistence.DiscriminatorValue;
 import javax.persistence.Entity;
-import javax.persistence.EnumType;
-import javax.persistence.Enumerated;
+import javax.persistence.FetchType;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
 
-import org.locationtech.jts.geom.Point;
-
-import com.huemap.backend.bin.domain.BinType;
+import com.huemap.backend.bin.domain.Bin;
 
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.NoArgsConstructor;
 
 @Entity
@@ -18,10 +17,15 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Presence extends Report {
 
-  @Column(columnDefinition = "GEOMETRY")
-  private Point location;
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "bin_id")
+  private Bin bin;
 
-  @Enumerated(EnumType.STRING)
-  private BinType type;
+  private int count;
 
+  @Builder
+  public Presence(final Long userId, final Bin bin) {
+    super(userId);
+    this.bin = bin;
+  }
 }

--- a/backend/src/test/java/com/huemap/backend/common/TestUtils.java
+++ b/backend/src/test/java/com/huemap/backend/common/TestUtils.java
@@ -25,6 +25,7 @@ public class TestUtils {
     ReflectionTestUtils.setField(bin, "address", "서울특별시 종로구 창덕궁7길 5");
     ReflectionTestUtils.setField(bin, "addressDescription", null);
     ReflectionTestUtils.setField(bin, "type", BinType.CLOTHES);
+    ReflectionTestUtils.setField(bin, "isCandidate", false);
     ReflectionTestUtils.setField(bin, "deleted", false);
 
     return bin;


### PR DESCRIPTION
* Bin 엔티티 isCandidate 필드 추가
  * 존재 폐수거함 제보에 대하여 고민하던중 Bin 엔티티에 isCandidate 필드를 추가하였습니다. 예비 Bin에 해당하는 테이블을 둘려고 했으나 Bin 중복된 데이터가 쌓인다고 생각하여 Bin 후보인지 아닌지 나타내는 isCandidate 필드를 추가하였습니다. 폐수거함 전체 조회를 할 때도 예비 Bin 테이블을 두게 되면 양쪽 테이블에 조회를 해야되기 때문에 불필요한 쿼리인거 같아 Bin 엔티티에 구분할 수 있는 필드를 추가함으로써 해결하는 방안이 좋은거 같습니다.
  * **데이터셋에서 삽입된 폐수거함 isCandidate = false, 존재 폐수거함 제보에 따른 후보 폐수거함 isCandidate = true**
* Presence 엔티티 수정
  * 존재 폐수거함 제보를 하게 되면 Bin 엔티티가 하나 생성되고, Presence 엔티티 하나가 추가됩니다.
  * 존재 폐수거함 투표를 하게 되면 Presence 엔티티의 count 값이 +1 증가됩니다.

> Bin 엔티티 필드 추가에 따른 폐수거함 전체 조회와 폐수거함 상세 조회 관련 response가 수정될 필요가 있을거 같습니다. 수정부탁드립니다.

![image](https://user-images.githubusercontent.com/78195316/199998966-0682f40d-f7c1-4c7d-a698-2b98a7465081.png)
