### PR TITLE
[#92] 후보 폐수거함 생성 & 존재 폐수거함 제보 구현

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -29,6 +29,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'mysql:mysql-connector-java'
 	implementation group: 'org.hibernate', name: 'hibernate-spatial', version: '5.6.11.Final'
+	implementation 'org.springframework.boot:spring-boot-starter-webflux'
 
 	implementation 'org.mapstruct:mapstruct:1.4.2.Final'
 	annotationProcessor "org.mapstruct:mapstruct-processor:1.4.2.Final"

--- a/backend/src/main/java/com/huemap/backend/bin/application/BinService.java
+++ b/backend/src/main/java/com/huemap/backend/bin/application/BinService.java
@@ -3,6 +3,7 @@ package com.huemap.backend.bin.application;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import org.locationtech.jts.geom.Point;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -13,8 +14,12 @@ import com.huemap.backend.bin.domain.mapper.BinDetailMapper;
 import com.huemap.backend.bin.domain.mapper.BinMapper;
 import com.huemap.backend.bin.dto.response.BinDetailResponse;
 import com.huemap.backend.bin.dto.response.BinResponse;
+import com.huemap.backend.bin.event.BinCreateEvent;
 import com.huemap.backend.common.exception.EntityNotFoundException;
+import com.huemap.backend.common.exception.InvalidValueException;
 import com.huemap.backend.common.response.error.ErrorCode;
+import com.huemap.backend.openApi.kakao.KakaoMapProvider;
+import com.huemap.backend.openApi.kakao.response.KakaoMapRoadAddress;
 import com.huemap.backend.report.domain.ReportRepository;
 
 import lombok.RequiredArgsConstructor;
@@ -26,6 +31,7 @@ public class BinService {
 
 	private final BinRepository binRepository;
 	private final ReportRepository reportRepository;
+	private final KakaoMapProvider kakaoMapProvider;
 
 	public List<BinResponse> findAll(final BinType type) {
 
@@ -43,5 +49,23 @@ public class BinService {
 		int count = reportRepository.countClosureByBin(id);
 
 		return BinDetailMapper.INSTANCE.toDto(bin, count != 0 ? true : false);
+	}
+
+	public void save(BinCreateEvent binCreateEvent) {
+		validateCandidateBinAlreadyExist(binCreateEvent.getType(), binCreateEvent.getLocation());
+
+		final KakaoMapRoadAddress addressInformation = kakaoMapProvider.getAddressInformation(
+				binCreateEvent.getLocation().getY(), binCreateEvent.getLocation().getX());
+
+		binRepository.save(Bin.candidateOf(binCreateEvent.getLocation(),
+																			 binCreateEvent.getType(),
+																			 addressInformation));
+	}
+
+	private void validateCandidateBinAlreadyExist(BinType type, Point location) {
+		binRepository.findCandidateBinByTypeAndLocation(type, location)
+								 .ifPresent(b -> {
+									 throw new InvalidValueException(ErrorCode.CANDIDATE_BIN_DUPLICATED);
+								 });
 	}
 }

--- a/backend/src/main/java/com/huemap/backend/bin/domain/Bin.java
+++ b/backend/src/main/java/com/huemap/backend/bin/domain/Bin.java
@@ -11,6 +11,7 @@ import org.hibernate.annotations.Where;
 import org.locationtech.jts.geom.Point;
 
 import com.huemap.backend.common.entity.BaseEntity;
+import com.huemap.backend.openApi.kakao.response.KakaoMapRoadAddress;
 
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -40,6 +41,42 @@ public class Bin extends BaseEntity {
 	private boolean isCandidate;
 
 	private boolean deleted;
+
+	private Bin(String gu,
+							Point location,
+							String address,
+							String addressDescription,
+							boolean isCandidate,
+							BinType type) {
+		this.gu = gu;
+		this.location = location;
+		this.address = address;
+		this.addressDescription = addressDescription;
+		this.isCandidate = isCandidate;
+		this.type = type;
+	}
+
+	public static Bin candidateOf(Point location,
+																BinType type,
+																KakaoMapRoadAddress addressInformation) {
+		if (addressInformation == null) {
+			final String latitudeLongitudeStr = location.getY() + " " + location.getX();
+			return new Bin(latitudeLongitudeStr,
+										 location,
+										 latitudeLongitudeStr,
+										 null,
+										 true,
+										 type
+										 );
+		}
+
+		return new Bin(addressInformation.getGu(),
+									 location,
+									 addressInformation.getAddress(),
+									 addressInformation.getAddressDescription(),
+									 true,
+									 type);
+	}
 
 	public void delete() {
 		this.deleted = true;

--- a/backend/src/main/java/com/huemap/backend/bin/domain/BinRepository.java
+++ b/backend/src/main/java/com/huemap/backend/bin/domain/BinRepository.java
@@ -1,7 +1,9 @@
 package com.huemap.backend.bin.domain;
 
 import java.util.List;
+import java.util.Optional;
 
+import org.locationtech.jts.geom.Point;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
@@ -17,4 +19,7 @@ public interface BinRepository extends JpaRepository<Bin, Long> {
 			+ "GROUP BY c.bin "
 			+ "HAVING COUNT(c.bin) >= :closureCount)")
 	List<Bin> findAllHasClosureOver(long closureCount);
+
+	Optional<Bin> findCandidateBinByTypeAndLocation(BinType type, Point location);
+
 }

--- a/backend/src/main/java/com/huemap/backend/bin/event/BinCreateEvent.java
+++ b/backend/src/main/java/com/huemap/backend/bin/event/BinCreateEvent.java
@@ -1,0 +1,20 @@
+package com.huemap.backend.bin.event;
+
+import org.locationtech.jts.geom.Point;
+
+import com.huemap.backend.bin.domain.BinType;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class BinCreateEvent {
+  private final BinType type;
+  private final Point location;
+
+  public static BinCreateEvent candidateOf(BinType type, Point location) {
+    return new BinCreateEvent(type, location);
+  }
+}

--- a/backend/src/main/java/com/huemap/backend/bin/event/BinEventHandler.java
+++ b/backend/src/main/java/com/huemap/backend/bin/event/BinEventHandler.java
@@ -1,0 +1,19 @@
+package com.huemap.backend.bin.event;
+
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Component;
+
+import com.huemap.backend.bin.application.BinService;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class BinEventHandler {
+  private final BinService binService;
+
+  @EventListener
+  public void createCandidateBin(BinCreateEvent binCreateEvent) {
+    binService.save(binCreateEvent);
+  }
+}

--- a/backend/src/main/java/com/huemap/backend/common/response/error/ErrorCode.java
+++ b/backend/src/main/java/com/huemap/backend/common/response/error/ErrorCode.java
@@ -10,7 +10,10 @@ public enum ErrorCode {
 	INTERNAL_SERVER_ERROR(500, "서버 내부에 오류가 생겼습니다."),
 	BIN_NOT_FOUND(400, "폐수거함을 찾을 수 없습니다."),
 	REPORT_DISTANCE_FAR(400, "제보하려는 대상과 사용자의 거리가 너무 멉니다."),
-	CLOSURE_DUPLICATED(400, "중복된 폐수거함 폐쇄 제보를 할 수 없습니다.");
+	CLOSURE_DUPLICATED(400, "중복된 폐수거함 폐쇄 제보를 할 수 없습니다."),
+	CANDIDATE_BIN_DUPLICATED(400, "이미 존재 제보된 후보 폐수거함이 존재합니다."),
+
+	KAKAO_MAP_REQUEST_INVALID(400, "카카오맵 OPEN API 요청 값이 적절하지 않습니다.");
 
 	private final int status;
 	private final String message;

--- a/backend/src/main/java/com/huemap/backend/common/utils/GeometryUtil.java
+++ b/backend/src/main/java/com/huemap/backend/common/utils/GeometryUtil.java
@@ -1,6 +1,20 @@
 package com.huemap.backend.common.utils;
 
+import org.locationtech.jts.geom.Point;
+import org.locationtech.jts.io.ParseException;
+import org.locationtech.jts.io.WKTReader;
+
 public class GeometryUtil {
+
+  public static Point convertPoint(Double latitude, Double longitude) {
+    try {
+      String pointWKT = String.format("POINT(%s %s)", longitude, latitude);
+      return (Point) new WKTReader().read(pointWKT);
+    }
+    catch (ParseException e) {
+      throw new RuntimeException(String.format( "Can't parse string %s as WKT"));
+    }
+  }
 
   public static double calculateDistance(Double latitude1,
                                          Double longitude1,

--- a/backend/src/main/java/com/huemap/backend/openApi/kakao/KakaoMapEnum.java
+++ b/backend/src/main/java/com/huemap/backend/openApi/kakao/KakaoMapEnum.java
@@ -1,0 +1,17 @@
+package com.huemap.backend.openApi.kakao;
+
+import lombok.Getter;
+
+@Getter
+public enum KakaoMapEnum {
+  BASE_URL("https://dapi.kakao.com/v2/local/geo/coord2address.json?"),
+  COORDINATE_X("x"),
+  COORDINATE_Y("y"),
+  KAKAO_AK("KakaoAK ");
+
+  private String value;
+
+  KakaoMapEnum(String value) {
+    this.value = value;
+  }
+}

--- a/backend/src/main/java/com/huemap/backend/openApi/kakao/KakaoMapProvider.java
+++ b/backend/src/main/java/com/huemap/backend/openApi/kakao/KakaoMapProvider.java
@@ -1,0 +1,43 @@
+package com.huemap.backend.openApi.kakao;
+
+import static com.huemap.backend.openApi.kakao.KakaoMapEnum.*;
+
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import com.huemap.backend.common.exception.InvalidValueException;
+import com.huemap.backend.common.response.error.ErrorCode;
+import com.huemap.backend.openApi.kakao.response.KakaoMap;
+import com.huemap.backend.openApi.kakao.response.KakaoMapRoadAddress;
+
+import lombok.RequiredArgsConstructor;
+import reactor.core.publisher.Mono;
+
+@Component
+@RequiredArgsConstructor
+public class KakaoMapProvider {
+  private final WebClient.Builder builder;
+
+  private final String KAKAO_REST_API_KEY = "30216f52aef05b360f528635c4b6796f";
+
+  public KakaoMapRoadAddress getAddressInformation(Double latitude, Double longitude) {
+    KakaoMap kakaoMap = requestAddressByCoordinate(latitude, longitude);
+    return kakaoMap.getRoadAddress();
+  }
+
+  private KakaoMap requestAddressByCoordinate(Double latitude, Double longitude) {
+    WebClient webClient = builder.baseUrl(BASE_URL.getValue()).build();
+    return webClient.get()
+                    .uri(uriBuilder -> uriBuilder
+                        .queryParam(COORDINATE_X.getValue(), longitude)
+                        .queryParam(COORDINATE_Y.getValue(), latitude)
+                        .build())
+                    .header(HttpHeaders.AUTHORIZATION, KAKAO_AK.getValue() + KAKAO_REST_API_KEY)
+                    .retrieve()
+                    .onStatus(HttpStatus::is4xxClientError, response -> Mono.error(new InvalidValueException(ErrorCode.KAKAO_MAP_REQUEST_INVALID)))
+                    .bodyToMono(KakaoMap.class)
+                    .block();
+  }
+}

--- a/backend/src/main/java/com/huemap/backend/openApi/kakao/response/KakaoMap.java
+++ b/backend/src/main/java/com/huemap/backend/openApi/kakao/response/KakaoMap.java
@@ -1,0 +1,19 @@
+package com.huemap.backend.openApi.kakao.response;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import lombok.Getter;
+
+@Getter
+public class KakaoMap {
+
+  @JsonProperty("documents")
+  private List<KakaoMapAddress> kakaoMapAddresses = new ArrayList<>();
+
+  public KakaoMapRoadAddress getRoadAddress() {
+    return kakaoMapAddresses.get(0).getKakaoMapRoadAddress();
+  }
+}

--- a/backend/src/main/java/com/huemap/backend/openApi/kakao/response/KakaoMapAddress.java
+++ b/backend/src/main/java/com/huemap/backend/openApi/kakao/response/KakaoMapAddress.java
@@ -1,0 +1,12 @@
+package com.huemap.backend.openApi.kakao.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import lombok.Getter;
+
+@Getter
+public class KakaoMapAddress {
+
+  @JsonProperty("road_address")
+  private KakaoMapRoadAddress kakaoMapRoadAddress = new KakaoMapRoadAddress();
+}

--- a/backend/src/main/java/com/huemap/backend/openApi/kakao/response/KakaoMapRoadAddress.java
+++ b/backend/src/main/java/com/huemap/backend/openApi/kakao/response/KakaoMapRoadAddress.java
@@ -1,0 +1,21 @@
+package com.huemap.backend.openApi.kakao.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import lombok.Getter;
+import lombok.ToString;
+
+@Getter
+@ToString
+public class KakaoMapRoadAddress {
+
+  @JsonProperty("address_name")
+  private String address;
+
+  @JsonProperty("region_2depth_name")
+  private String gu;
+
+  @JsonProperty("building_name")
+  private String addressDescription;
+
+}

--- a/backend/src/main/java/com/huemap/backend/report/application/ReportService.java
+++ b/backend/src/main/java/com/huemap/backend/report/application/ReportService.java
@@ -1,20 +1,29 @@
 package com.huemap.backend.report.application;
 
+import static com.huemap.backend.common.utils.GeometryUtil.*;
+
+import org.locationtech.jts.geom.Point;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.huemap.backend.bin.domain.Bin;
 import com.huemap.backend.bin.domain.BinRepository;
+import com.huemap.backend.bin.domain.BinType;
+import com.huemap.backend.bin.event.BinCreateEvent;
 import com.huemap.backend.common.exception.EntityNotFoundException;
 import com.huemap.backend.common.exception.InvalidValueException;
 import com.huemap.backend.common.response.error.ErrorCode;
 import com.huemap.backend.common.utils.GeometryUtil;
 import com.huemap.backend.report.domain.Closure;
+import com.huemap.backend.report.domain.Presence;
 import com.huemap.backend.report.domain.ReportRepository;
 import com.huemap.backend.report.domain.mapper.ClosureMapper;
+import com.huemap.backend.report.domain.mapper.PresenceMapper;
 import com.huemap.backend.report.dto.request.ClosureCreateRequest;
 import com.huemap.backend.report.dto.request.PresenceCreateRequest;
 import com.huemap.backend.report.dto.response.ClosureCreateResponse;
+import com.huemap.backend.report.dto.response.PresenceCreateResponse;
 
 import lombok.RequiredArgsConstructor;
 
@@ -25,6 +34,7 @@ public class ReportService {
 
   private final ReportRepository reportRepository;
   private final BinRepository binRepository;
+  private final ApplicationEventPublisher publisher;
 
   private final double DISTANCE_METER = 10;
 
@@ -39,7 +49,7 @@ public class ReportService {
 
     validateDistanceBetweenUserAndBin(bin, closureCreateRequest.getLatitude(),
                                       closureCreateRequest.getLongitude());
-    validateAlreadyExist(userId, bin);
+    validateClosureAlreadyExist(userId, bin);
 
     final Closure closure = (Closure)reportRepository.save(ClosureMapper.INSTANCE.toEntity(userId, bin));
 
@@ -47,12 +57,22 @@ public class ReportService {
   }
 
   @Transactional
-  public Object savePresence(Long userId, PresenceCreateRequest presenceCreateRequest) {
-    return null;
+  public PresenceCreateResponse savePresence(Long userId, PresenceCreateRequest presenceCreateRequest) {
+    final BinType type = presenceCreateRequest.getType();
+    final Point location = convertPoint(presenceCreateRequest.getLatitude(),
+                                        presenceCreateRequest.getLongitude());
+    publisher.publishEvent(BinCreateEvent.candidateOf(type, location));
+
+    final Bin bin = binRepository.findCandidateBinByTypeAndLocation(type, location)
+                                 .orElseThrow(() -> new EntityNotFoundException(ErrorCode.BIN_NOT_FOUND));
+
+    final Presence presence = (Presence)reportRepository.save(Presence.of(userId, bin));
+
+    return PresenceMapper.INSTANCE.toDto(presence);
   }
 
-  private void validateAlreadyExist(Long userId, Bin bin) {
-    reportRepository.findByUserIdAndBin(userId, bin)
+  private void validateClosureAlreadyExist(Long userId, Bin bin) {
+    reportRepository.findClosureByUserIdAndBin(userId, bin)
                     .ifPresent(c -> {throw new InvalidValueException(ErrorCode.CLOSURE_DUPLICATED);});
   }
 

--- a/backend/src/main/java/com/huemap/backend/report/application/ReportService.java
+++ b/backend/src/main/java/com/huemap/backend/report/application/ReportService.java
@@ -77,7 +77,7 @@ public class ReportService {
   }
 
   private void validateDistanceBetweenUserAndBin(Bin bin, Double userLatitude, Double userLongitude) {
-정    if (GeometryUtil.calculateDistance(bin.getLocation().getY(), bin.getLocation().getX(),
+    if (GeometryUtil.calculateDistance(bin.getLocation().getY(), bin.getLocation().getX(),
                                        userLatitude, userLongitude) > DISTANCE_METER) {
       throw new InvalidValueException(ErrorCode.REPORT_DISTANCE_FAR);
     }

--- a/backend/src/main/java/com/huemap/backend/report/application/ReportService.java
+++ b/backend/src/main/java/com/huemap/backend/report/application/ReportService.java
@@ -77,7 +77,7 @@ public class ReportService {
   }
 
   private void validateDistanceBetweenUserAndBin(Bin bin, Double userLatitude, Double userLongitude) {
-    if (GeometryUtil.calculateDistance(bin.getLocation().getX(), bin.getLocation().getY(),
+정    if (GeometryUtil.calculateDistance(bin.getLocation().getY(), bin.getLocation().getX(),
                                        userLatitude, userLongitude) > DISTANCE_METER) {
       throw new InvalidValueException(ErrorCode.REPORT_DISTANCE_FAR);
     }

--- a/backend/src/main/java/com/huemap/backend/report/domain/Presence.java
+++ b/backend/src/main/java/com/huemap/backend/report/domain/Presence.java
@@ -9,7 +9,6 @@ import javax.persistence.ManyToOne;
 import com.huemap.backend.bin.domain.Bin;
 
 import lombok.AccessLevel;
-import lombok.Builder;
 import lombok.NoArgsConstructor;
 
 @Entity
@@ -23,9 +22,13 @@ public class Presence extends Report {
 
   private int count;
 
-  @Builder
-  public Presence(final Long userId, final Bin bin) {
+  private Presence(final Long userId, final Bin bin) {
     super(userId);
     this.bin = bin;
+    this.count = 1;
+  }
+
+  public static Presence of(final Long userId, final Bin bin) {
+    return new Presence(userId, bin);
   }
 }

--- a/backend/src/main/java/com/huemap/backend/report/domain/ReportRepository.java
+++ b/backend/src/main/java/com/huemap/backend/report/domain/ReportRepository.java
@@ -10,7 +10,7 @@ import com.huemap.backend.bin.domain.Bin;
 
 public interface ReportRepository<T extends Report> extends JpaRepository<T, Long> {
 
-	Optional<Closure> findByUserIdAndBin(Long userId, Bin bin);
+	Optional<Closure> findClosureByUserIdAndBin(Long userId, Bin bin);
 
 	@Query("select count(c) from Closure c where c.bin.id = :binId")
 	int countClosureByBin(@Param("binId") Long binId);

--- a/backend/src/main/java/com/huemap/backend/report/domain/mapper/PresenceMapper.java
+++ b/backend/src/main/java/com/huemap/backend/report/domain/mapper/PresenceMapper.java
@@ -1,0 +1,20 @@
+package com.huemap.backend.report.domain.mapper;
+
+import org.mapstruct.InjectionStrategy;
+import org.mapstruct.Mapper;
+import org.mapstruct.ReportingPolicy;
+import org.mapstruct.factory.Mappers;
+
+import com.huemap.backend.report.domain.Presence;
+import com.huemap.backend.report.dto.response.PresenceCreateResponse;
+
+@Mapper(
+    componentModel = "spring",
+    injectionStrategy = InjectionStrategy.CONSTRUCTOR,
+    unmappedTargetPolicy = ReportingPolicy.ERROR
+)
+public interface PresenceMapper {
+  PresenceMapper INSTANCE = Mappers.getMapper(PresenceMapper.class);
+
+  PresenceCreateResponse toDto(Presence presence);
+}

--- a/backend/src/main/java/com/huemap/backend/report/dto/response/PresenceCreateResponse.java
+++ b/backend/src/main/java/com/huemap/backend/report/dto/response/PresenceCreateResponse.java
@@ -7,7 +7,6 @@ import lombok.NoArgsConstructor;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
-
 public class PresenceCreateResponse {
 
   private Long id;

--- a/backend/src/test/java/com/huemap/backend/common/TestUtils.java
+++ b/backend/src/test/java/com/huemap/backend/common/TestUtils.java
@@ -17,7 +17,7 @@ public class TestUtils {
     constructor.setAccessible(true);
     Bin bin = (Bin)constructor.newInstance();
 
-    String pointWKT = String.format("POINT(%s %s)", 37.5833354, 126.9876779);
+    String pointWKT = String.format("POINT(%s %s)", 126.9876779, 37.5833354);
     Point point = (Point) new WKTReader().read(pointWKT);
 
     ReflectionTestUtils.setField(bin, "gu", "종로구");

--- a/backend/src/test/java/com/huemap/backend/report/application/ReportServiceTest.java
+++ b/backend/src/test/java/com/huemap/backend/report/application/ReportServiceTest.java
@@ -107,7 +107,7 @@ public class ReportServiceTest {
     }
 
     @Nested
-    @DisplayName("이미 같은 폐수거함을 폐쇄 제보한 상태에서 폐쇄 제보를 한다면")
+    @DisplayName("유효한 값이 넘어오면")
     class Context_with_valid_argument {
 
       @Test

--- a/backend/src/test/java/com/huemap/backend/report/application/ReportServiceTest.java
+++ b/backend/src/test/java/com/huemap/backend/report/application/ReportServiceTest.java
@@ -95,7 +95,7 @@ public class ReportServiceTest {
         final Bin bin = getBin();
         final Closure closure = getClosure(bin);
         given(binRepository.findById(anyLong())).willReturn(Optional.of(bin));
-        given(reportRepository.findByUserIdAndBin(anyLong(), any(Bin.class))).willReturn(Optional.of(closure));
+        given(reportRepository.findClosureByUserIdAndBin(anyLong(), any(Bin.class))).willReturn(Optional.of(closure));
 
         // when, then
         assertThatThrownBy(
@@ -118,7 +118,7 @@ public class ReportServiceTest {
         final Bin bin = getBin();
         final Closure closure = getClosure(bin);
         given(binRepository.findById(anyLong())).willReturn(Optional.of(bin));
-        given(reportRepository.findByUserIdAndBin(anyLong(), any(Bin.class))).willReturn(Optional.empty());
+        given(reportRepository.findClosureByUserIdAndBin(anyLong(), any(Bin.class))).willReturn(Optional.empty());
         given(reportRepository.save(any(Closure.class))).willReturn(closure);
 
         // when

--- a/backend/src/test/java/com/huemap/backend/report/domain/ReportRepositoryTest.java
+++ b/backend/src/test/java/com/huemap/backend/report/domain/ReportRepositoryTest.java
@@ -41,7 +41,7 @@ public class ReportRepositoryTest {
         final Closure expected = (Closure)reportRepository.save(getClosure(bin));
 
         //when
-        final Optional<Closure> actual = reportRepository.findByUserIdAndBin(userId, bin);
+        final Optional<Closure> actual = reportRepository.findClosureByUserIdAndBin(userId, bin);
 
         //then
         assertThat(actual).isNotEmpty();


### PR DESCRIPTION
* 후보 폐수거함 생성
  * 존재 폐수거함 제보를 할 때 위도, 경도, 폐수거함 type을 담아서 요청하는데, 해당 요청값들에 대한 후보 폐수거함이 없다면 후보 폐수거함을 생성하게 됩니다.
  * 후보 폐수거함 생성 로직이 report에 존재하는 것이 옳지 않고 binService를  주입 받아서 하는 것도 의존성 문제로 인해 결합도가 높아질 것이라고 생각하여 이벤트 핸들러를 도입하였습니다.
  * 후보 폐수거함을 생성할 때 Bin 엔티티에 address와 gu, address_description 값을 얻기 위하여 카카오맵 open api를 적용하였습니다.
    * https://developers.kakao.com/docs/latest/ko/local/dev-guide#coord-to-address
    * 위도, 경도 값으로 요청값을 보내면 해당 위치에 대한 도로명주소를 얻게됩니다.
    * 하지만 도로명 주소는 좌표에 따라 반환되지 않을 수도 있기 때문에, 존재하지 않은 도로명주소에 대해서는 address, gu에 위도 경도 값을 임시방편으로 삽입하였습니다. 이에 대하여 추후에 수정이 필요해보입니다.
* 존재 폐수거함 제보 구현
  * 등록된 후보 폐수거함에 대한 제보 엔티티가 생성됩니다.
  * count 값이 1로 된 상태로 생성됩니다.