### PR TITLE
[#107] 존재 폐수거함 제보 단위 통합 테스트 구현

### DIFF
--- a/backend/src/test/java/com/huemap/backend/bin/application/BinServiceTest.java
+++ b/backend/src/test/java/com/huemap/backend/bin/application/BinServiceTest.java
@@ -1,0 +1,97 @@
+package com.huemap.backend.bin.application;
+
+import static com.huemap.backend.common.TestUtils.*;
+import static com.huemap.backend.common.utils.GeometryUtil.*;
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.*;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.locationtech.jts.geom.Point;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.huemap.backend.bin.domain.Bin;
+import com.huemap.backend.bin.domain.BinRepository;
+import com.huemap.backend.bin.domain.BinType;
+import com.huemap.backend.bin.event.BinCreateEvent;
+import com.huemap.backend.common.exception.InvalidValueException;
+import com.huemap.backend.common.response.error.ErrorCode;
+import com.huemap.backend.openApi.kakao.KakaoMapProvider;
+import com.huemap.backend.openApi.kakao.response.KakaoMapRoadAddress;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("BinService의")
+public class BinServiceTest {
+
+  @InjectMocks
+  private BinService binService;
+
+  @Mock
+  private BinRepository binRepository;
+
+  @Mock
+  private KakaoMapProvider kakaoMapProvider;
+
+  @Nested
+  @DisplayName("save 메소드")
+  class save {
+
+    @Nested
+    @DisplayName("이미 존재하는 폐수거함을 저장할려고 한다면")
+    class Context_with_already_exist_bin {
+
+      @Test
+      @DisplayName("예외를 던진다.")
+      void It_throws_exception() throws Exception {
+        //given
+        final BinCreateEvent event = BinCreateEvent.candidateOf(BinType.CLOTHES,
+                                                                convertPoint(37.583297,
+                                                                             126.987755));
+        final Bin bin = getBin();
+        given(binRepository.findCandidateBinByTypeAndLocation(any(BinType.class),
+                                                              any(Point.class)))
+            .willReturn(Optional.of(bin));
+
+        // when, then
+        assertThatThrownBy(
+            () -> binService.save(event))
+            .isInstanceOf(InvalidValueException.class)
+            .extracting("errorCode")
+            .isEqualTo(ErrorCode.CANDIDATE_BIN_DUPLICATED);
+      }
+    }
+
+    @Nested
+    @DisplayName("유효한 값이 넘어오면")
+    class Context_with_valid_argument {
+
+      @Test
+      @DisplayName("폐수거함을 저장한다.")
+      void success() throws Exception {
+        //given
+        final BinCreateEvent event = BinCreateEvent.candidateOf(BinType.CLOTHES,
+                                                                convertPoint(37.583297,
+                                                                             126.987755));
+        final Bin bin = getBin();
+        given(binRepository.findCandidateBinByTypeAndLocation(any(BinType.class),
+                                                              any(Point.class)))
+            .willReturn(Optional.empty());
+        given(binRepository.save(any(Bin.class))).willReturn(bin);
+
+        //when
+        binService.save(event);
+
+        //then
+        verify(binRepository).save(any(Bin.class));
+      }
+    }
+  }
+}

--- a/backend/src/test/java/com/huemap/backend/bin/event/BinEventHandlerIntegrationTest.java
+++ b/backend/src/test/java/com/huemap/backend/bin/event/BinEventHandlerIntegrationTest.java
@@ -1,0 +1,57 @@
+package com.huemap.backend.bin.event;
+
+import static com.huemap.backend.common.utils.GeometryUtil.*;
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import com.huemap.backend.bin.domain.Bin;
+import com.huemap.backend.bin.domain.BinRepository;
+import com.huemap.backend.bin.domain.BinType;
+
+@SpringBootTest
+@DisplayName("BinEventHandler의")
+public class BinEventHandlerIntegrationTest {
+
+  @Autowired
+  private BinEventHandler binEventHandler;
+
+  @Autowired
+  private BinRepository binRepository;
+
+  @Nested
+  @DisplayName("createCandidateBin 메소드는")
+  class createCandidateBin {
+
+    @Nested
+    @DisplayName("폐수거함 생성 이벤트가 발생하면")
+    class Context_with_bin_create_event {
+
+      @Test
+      @DisplayName("후보 폐수거함이 저장된다.")
+      void It_save_candidate_bin() {
+        //given
+        final BinCreateEvent binCreateEvent = BinCreateEvent.candidateOf(BinType.CLOTHES,
+                                                                         convertPoint(37.583297,
+                                                                                      126.987755));
+
+        //when
+        binEventHandler.createCandidateBin(binCreateEvent);
+
+        //then
+        final Bin bin = binRepository.findAll().get(0);
+        assertAll(
+            () -> assertThat(bin.getType()).isEqualTo(BinType.CLOTHES),
+            () -> assertThat(bin.getLocation().getY()).isEqualTo(37.583297),
+            () -> assertThat(bin.getLocation().getX()).isEqualTo(126.987755),
+            () -> assertThat(bin.isCandidate()).isTrue()
+        );
+      }
+    }
+  }
+}

--- a/backend/src/test/java/com/huemap/backend/common/TestUtils.java
+++ b/backend/src/test/java/com/huemap/backend/common/TestUtils.java
@@ -9,6 +9,7 @@ import org.springframework.test.util.ReflectionTestUtils;
 import com.huemap.backend.bin.domain.Bin;
 import com.huemap.backend.bin.domain.BinType;
 import com.huemap.backend.report.domain.Closure;
+import com.huemap.backend.report.domain.Presence;
 
 public class TestUtils {
   public static Bin getBin() throws Exception {
@@ -38,5 +39,9 @@ public class TestUtils {
                              .build();
 
     return closure;
+  }
+
+  public static Presence getPresence(Bin bin) {
+    return Presence.of(1L, bin);
   }
 }

--- a/backend/src/test/java/com/huemap/backend/openApi/KakaoMapProviderIntegrationTest.java
+++ b/backend/src/test/java/com/huemap/backend/openApi/KakaoMapProviderIntegrationTest.java
@@ -1,0 +1,45 @@
+package com.huemap.backend.openApi;
+
+import static org.assertj.core.api.Assertions.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import com.huemap.backend.openApi.kakao.KakaoMapProvider;
+import com.huemap.backend.openApi.kakao.response.KakaoMapRoadAddress;
+
+@SpringBootTest
+@DisplayName("KakaoMapProvider의")
+public class KakaoMapProviderIntegrationTest {
+
+  @Autowired
+  private KakaoMapProvider kakaoMapProvider;
+
+  @Nested
+  @DisplayName("getAddressInformation 메소드는 위도와 경도 값이 주어지면")
+  class Context_with_latitude_longitude {
+
+    @Test
+    @DisplayName("Kakao Map OPEN API를 사용하여 해당 위치에 대한 도로명 주소를 응답한다.")
+   void It_response_address() {
+      //given
+      final Double latitude = 37.5825627;
+      final Double longitude = 127.059971;
+      final String address = "서울특별시 동대문구 서울시립대로 163";
+      final String gu = "동대문구";
+      final String addressDescription = "서울시립대학교";
+
+      //when
+      final KakaoMapRoadAddress addressInformation = kakaoMapProvider.getAddressInformation(latitude,
+                                                                                            longitude);
+
+      //then
+      assertThat(addressInformation.getAddress()).isEqualTo(address);
+      assertThat(addressInformation.getGu()).isEqualTo(gu);
+      assertThat(addressInformation.getAddressDescription()).isEqualTo(addressDescription);
+    }
+  }
+}


### PR DESCRIPTION
* 카카오맵 open api 주소 변환 통합테스트와 폐수거함 생성 이벤트 통합 테스트를 구현하였습니다.
* 존재 폐수거함 단위 테스트 구현