### PR TITLE
[#125] 폐수거함 전체 조회 local cache 적용

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -31,6 +31,9 @@ dependencies {
 	implementation group: 'org.hibernate', name: 'hibernate-spatial', version: '5.6.11.Final'
 	implementation 'org.springframework.boot:spring-boot-starter-webflux'
 
+	implementation 'org.springframework.boot:spring-boot-starter-cache'
+	implementation 'com.github.ben-manes.caffeine:caffeine'
+
 	implementation 'org.mapstruct:mapstruct:1.4.2.Final'
 	annotationProcessor "org.mapstruct:mapstruct-processor:1.4.2.Final"
 	annotationProcessor 'org.projectlombok:lombok-mapstruct-binding:0.1.0'

--- a/backend/src/main/java/com/huemap/backend/bin/presentation/BinController.java
+++ b/backend/src/main/java/com/huemap/backend/bin/presentation/BinController.java
@@ -1,5 +1,6 @@
 package com.huemap.backend.bin.presentation;
 
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -20,6 +21,7 @@ public class BinController {
 
 	private final BinService binService;
 
+	@Cacheable(cacheNames = "bins")
 	@GetMapping
 	public ResponseEntity<RestResponse> findAll(@RequestParam("type") BinType type) {
 

--- a/backend/src/main/java/com/huemap/backend/common/config/CacheConfig.java
+++ b/backend/src/main/java/com/huemap/backend/common/config/CacheConfig.java
@@ -1,0 +1,40 @@
+package com.huemap.backend.common.config;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.cache.caffeine.CaffeineCache;
+import org.springframework.cache.support.SimpleCacheManager;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import com.github.benmanes.caffeine.cache.Caffeine;
+
+@EnableCaching
+@Configuration
+public class CacheConfig {
+
+  @Bean
+  public CacheManager cacheManager() {
+    List<CaffeineCache> caches = Arrays.stream(CacheType.values())
+                                       .map(cache -> new CaffeineCache(cache.getCacheName(),
+                                                                       Caffeine.newBuilder()
+                                                                               .recordStats()
+                                                                               .expireAfterWrite(
+                                                                                   cache.getExpireAfterWrite(),
+                                                                                   TimeUnit.SECONDS)
+                                                                               .maximumSize(
+                                                                                   cache.getMaximumSize())
+                                                                               .build()))
+                                       .collect(Collectors.toList());
+
+    SimpleCacheManager cacheManager = new SimpleCacheManager();
+    cacheManager.setCaches(caches);
+
+    return cacheManager;
+  }
+}

--- a/backend/src/main/java/com/huemap/backend/common/config/CacheType.java
+++ b/backend/src/main/java/com/huemap/backend/common/config/CacheType.java
@@ -1,0 +1,22 @@
+package com.huemap.backend.common.config;
+
+import lombok.Getter;
+
+@Getter
+public enum CacheType {
+  USERS("bins",
+        5 * 60,
+        10000
+  );
+
+  CacheType(String cacheName, int expireAfterWrite, int maximumSize) {
+    this.cacheName = cacheName;
+    this.expireAfterWrite = expireAfterWrite;
+    this.maximumSize = maximumSize;
+  }
+
+  private final String cacheName;
+  private final int expireAfterWrite;
+  private final int maximumSize;
+
+}

--- a/backend/src/main/java/com/huemap/backend/common/config/CacheType.java
+++ b/backend/src/main/java/com/huemap/backend/common/config/CacheType.java
@@ -4,7 +4,7 @@ import lombok.Getter;
 
 @Getter
 public enum CacheType {
-  USERS("bins",
+  BINS("bins",
         5 * 60,
         10000
   );


### PR DESCRIPTION
* Local cache 라이브러리인 Caffeine cache 를 도입하여 폐수거함 전체 조회 api 호출 시간을 성능 개선하였습니다.
* 캐시 적용 전 첫 조회시 2.16s -> 캐시 적용 후 17ms
<img width="1362" alt="휴맵 전체 조회 캐시 적용 전(2 16s)" src="https://user-images.githubusercontent.com/78195316/200502100-82279e78-cc9f-4ec0-8171-1ef2d4192a33.png">
<img width="1364" alt="휴맵 전체 조회 캐시 적용 후(17ms)" src="https://user-images.githubusercontent.com/78195316/200502121-fb4e34db-e803-41f5-9c35-4832dfef8847.png">
