### PR TITLE
[#152] redis session 추가

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -49,6 +49,7 @@ dependencies {
 	testCompileOnly 'org.projectlombok:lombok'
 	testAnnotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'io.findify:s3mock_2.12:0.2.4'
+	testImplementation ('it.ozimov:embedded-redis:0.7.3') { exclude group: "org.slf4j", module: "slf4j-simple" }
 }
 
 tasks.named('test') {

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -30,6 +30,8 @@ dependencies {
 	implementation 'mysql:mysql-connector-java'
 	implementation group: 'org.hibernate', name: 'hibernate-spatial', version: '5.6.11.Final'
 	implementation 'org.springframework.boot:spring-boot-starter-webflux'
+	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+	implementation 'org.springframework.session:spring-session-data-redis'
 
 	implementation 'org.springframework.boot:spring-boot-starter-cache'
 	implementation 'com.github.ben-manes.caffeine:caffeine'

--- a/backend/src/main/java/com/huemap/backend/BackendApplication.java
+++ b/backend/src/main/java/com/huemap/backend/BackendApplication.java
@@ -4,7 +4,9 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 import org.springframework.scheduling.annotation.EnableScheduling;
+import org.springframework.session.data.redis.config.annotation.web.http.EnableRedisHttpSession;
 
+@EnableRedisHttpSession
 @EnableJpaAuditing
 @EnableScheduling
 @SpringBootApplication

--- a/backend/src/main/java/com/huemap/backend/common/config/RedisConfig.java
+++ b/backend/src/main/java/com/huemap/backend/common/config/RedisConfig.java
@@ -1,0 +1,16 @@
+package com.huemap.backend.common.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+
+@Configuration
+public class RedisConfig {
+
+  @Bean
+  public RedisConnectionFactory redisConnectionFactory() {
+    return new LettuceConnectionFactory();
+  }
+
+}

--- a/backend/src/main/java/com/huemap/backend/common/config/RedisConfig.java
+++ b/backend/src/main/java/com/huemap/backend/common/config/RedisConfig.java
@@ -1,5 +1,6 @@
 package com.huemap.backend.common.config;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
@@ -8,9 +9,15 @@ import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactor
 @Configuration
 public class RedisConfig {
 
+  @Value("${spring.redis.host}")
+  private String host;
+
+  @Value("${spring.redis.port}")
+  private int port;
+
   @Bean
   public RedisConnectionFactory redisConnectionFactory() {
-    return new LettuceConnectionFactory();
+    return new LettuceConnectionFactory(host, port);
   }
 
 }

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -11,6 +11,11 @@ spring:
     hibernate:
       format_sql: true
       ddl-auto: update
+  session:
+    storage-type: redis
+  redis:
+    host: localhost
+    port: 6379
 
 cloud:
   aws:

--- a/backend/src/test/java/com/huemap/backend/common/scheduler/SchedulerServiceIntegrationTest.java
+++ b/backend/src/test/java/com/huemap/backend/common/scheduler/SchedulerServiceIntegrationTest.java
@@ -1,6 +1,6 @@
 package com.huemap.backend.common.scheduler;
 
-import static com.huemap.backend.common.TestUtils.*;
+import static com.huemap.backend.support.TestUtils.*;
 import static org.assertj.core.api.Assertions.*;
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -12,7 +12,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.util.ReflectionTestUtils;
 
-import com.huemap.backend.common.IntegrationTest;
+import com.huemap.backend.support.IntegrationTest;
 import com.huemap.backend.domain.bin.domain.Bin;
 import com.huemap.backend.domain.bin.domain.BinRepository;
 import com.huemap.backend.domain.report.domain.Closure;

--- a/backend/src/test/java/com/huemap/backend/domain/bin/application/BinServiceTest.java
+++ b/backend/src/test/java/com/huemap/backend/domain/bin/application/BinServiceTest.java
@@ -1,6 +1,6 @@
 package com.huemap.backend.domain.bin.application;
 
-import static com.huemap.backend.common.TestUtils.getBin;
+import static com.huemap.backend.support.TestUtils.getBin;
 import static com.huemap.backend.common.utils.GeometryUtil.convertPoint;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -22,7 +22,6 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import com.huemap.backend.domain.bin.application.BinService;
 import com.huemap.backend.domain.bin.domain.Bin;
 import com.huemap.backend.domain.bin.domain.BinRepository;
 import com.huemap.backend.domain.bin.domain.BinType;

--- a/backend/src/test/java/com/huemap/backend/domain/bin/domain/BinRepositoryTest.java
+++ b/backend/src/test/java/com/huemap/backend/domain/bin/domain/BinRepositoryTest.java
@@ -1,6 +1,6 @@
 package com.huemap.backend.domain.bin.domain;
 
-import static com.huemap.backend.common.TestUtils.getBin;
+import static com.huemap.backend.support.TestUtils.getBin;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.List;
@@ -8,19 +8,11 @@ import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 
-import com.huemap.backend.domain.bin.domain.Bin;
-import com.huemap.backend.domain.bin.domain.BinRepository;
-import com.huemap.backend.domain.bin.domain.BinType;
+import com.huemap.backend.support.RepositoryTest;
 
-@DataJpaTest
 @DisplayName("BinRepository의")
-public class BinRepositoryTest {
-
-	@Autowired
-	private BinRepository binRepository;
+public class BinRepositoryTest extends RepositoryTest {
 
 	@Nested
 	@DisplayName("findAllByType 메소드는")

--- a/backend/src/test/java/com/huemap/backend/domain/bin/event/BinEventHandlerIntegrationTest.java
+++ b/backend/src/test/java/com/huemap/backend/domain/bin/event/BinEventHandlerIntegrationTest.java
@@ -9,7 +9,7 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
-import com.huemap.backend.common.IntegrationTest;
+import com.huemap.backend.support.IntegrationTest;
 import com.huemap.backend.domain.bin.domain.Bin;
 import com.huemap.backend.domain.bin.domain.BinRepository;
 import com.huemap.backend.domain.bin.domain.BinType;

--- a/backend/src/test/java/com/huemap/backend/domain/bin/presentation/BinControllerTest.java
+++ b/backend/src/test/java/com/huemap/backend/domain/bin/presentation/BinControllerTest.java
@@ -1,6 +1,6 @@
 package com.huemap.backend.domain.bin.presentation;
 
-import static com.huemap.backend.common.TestUtils.getBin;
+import static com.huemap.backend.support.TestUtils.getBin;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.BDDMockito.given;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -12,31 +12,18 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
 import org.springframework.http.MediaType;
-import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 
-import com.huemap.backend.domain.bin.application.BinService;
+import com.huemap.backend.support.ControllerTest;
 import com.huemap.backend.domain.bin.domain.Bin;
 import com.huemap.backend.domain.bin.dto.response.BinDetailResponse;
 import com.huemap.backend.common.exception.EntityNotFoundException;
 import com.huemap.backend.common.response.error.ErrorCode;
-import com.huemap.backend.domain.bin.presentation.BinController;
 
-@WebMvcTest(BinController.class)
-@MockBean(JpaMetamodelMappingContext.class)
+
 @DisplayName("BinController의")
-public class BinControllerTest {
-
-	@Autowired
-	private MockMvc mockMvc;
-
-	@MockBean
-	private BinService binService;
+public class BinControllerTest extends ControllerTest {
 
 	@Nested
 	@DisplayName("findAll 메소드는")

--- a/backend/src/test/java/com/huemap/backend/domain/report/application/ReportServiceTest.java
+++ b/backend/src/test/java/com/huemap/backend/domain/report/application/ReportServiceTest.java
@@ -1,6 +1,6 @@
 package com.huemap.backend.domain.report.application;
 
-import static com.huemap.backend.common.TestUtils.*;
+import static com.huemap.backend.support.TestUtils.*;
 import static org.assertj.core.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.BDDMockito.*;

--- a/backend/src/test/java/com/huemap/backend/domain/report/domain/ReportRepositoryTest.java
+++ b/backend/src/test/java/com/huemap/backend/domain/report/domain/ReportRepositoryTest.java
@@ -1,6 +1,6 @@
 package com.huemap.backend.domain.report.domain;
 
-import static com.huemap.backend.common.TestUtils.*;
+import static com.huemap.backend.support.TestUtils.*;
 import static org.assertj.core.api.Assertions.*;
 
 import java.util.Optional;
@@ -8,23 +8,12 @@ import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 
 import com.huemap.backend.domain.bin.domain.Bin;
-import com.huemap.backend.domain.bin.domain.BinRepository;
-import com.huemap.backend.domain.report.domain.Closure;
-import com.huemap.backend.domain.report.domain.ReportRepository;
+import com.huemap.backend.support.RepositoryTest;
 
-@DataJpaTest
 @DisplayName("ReportRepository의")
-public class ReportRepositoryTest {
-
-  @Autowired
-  private ReportRepository reportRepository;
-
-  @Autowired
-  private BinRepository binRepository;
+public class ReportRepositoryTest extends RepositoryTest {
 
   @Nested
   @DisplayName("findByUserIdAndBin 메소드는")

--- a/backend/src/test/java/com/huemap/backend/domain/report/presentation/ReportControllerTest.java
+++ b/backend/src/test/java/com/huemap/backend/domain/report/presentation/ReportControllerTest.java
@@ -13,24 +13,18 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
 import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockMultipartFile;
-import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.web.multipart.MultipartFile;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
+import com.huemap.backend.support.ControllerTest;
 import com.huemap.backend.domain.bin.domain.BinType;
 import com.huemap.backend.common.exception.EntityNotFoundException;
 import com.huemap.backend.common.exception.InvalidValueException;
 import com.huemap.backend.common.response.error.ErrorCode;
 import com.huemap.backend.common.response.success.RestResponse;
 import com.huemap.backend.domain.bin.domain.ConditionType;
-import com.huemap.backend.domain.report.application.ReportService;
 import com.huemap.backend.domain.report.dto.request.ClosureCreateRequest;
 import com.huemap.backend.domain.report.dto.request.ConditionCreateRequest;
 import com.huemap.backend.domain.report.dto.request.PresenceCreateRequest;
@@ -39,19 +33,9 @@ import com.huemap.backend.domain.report.dto.response.ClosureCreateResponse;
 import com.huemap.backend.domain.report.dto.response.ConditionCreateResponse;
 import com.huemap.backend.domain.report.dto.response.PresenceCreateResponse;
 
-@WebMvcTest(ReportController.class)
-@MockBean(JpaMetamodelMappingContext.class)
+
 @DisplayName("ReportController의")
-public class ReportControllerTest {
-
-  @Autowired
-  private MockMvc mockMvc;
-
-  @Autowired
-  private ObjectMapper objectMapper;
-
-  @MockBean
-  private ReportService reportService;
+public class ReportControllerTest extends ControllerTest {
 
   @Nested
   @DisplayName("saveClosure 메소드는")

--- a/backend/src/test/java/com/huemap/backend/infrastructure/openApi/KakaoMapProviderIntegrationTest.java
+++ b/backend/src/test/java/com/huemap/backend/infrastructure/openApi/KakaoMapProviderIntegrationTest.java
@@ -6,12 +6,10 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.mock.mockito.MockBean;
 
-import com.huemap.backend.common.IntegrationTest;
+import com.huemap.backend.support.IntegrationTest;
 import com.huemap.backend.infrastructure.openApi.kakao.KakaoMapProvider;
 import com.huemap.backend.infrastructure.openApi.kakao.response.KakaoMapRoadAddress;
-import com.huemap.backend.infrastructure.s3.S3Uploader;
 
 @DisplayName("KakaoMapProvider의")
 public class KakaoMapProviderIntegrationTest extends IntegrationTest {

--- a/backend/src/test/java/com/huemap/backend/infrastructure/s3/S3UploaderTest.java
+++ b/backend/src/test/java/com/huemap/backend/infrastructure/s3/S3UploaderTest.java
@@ -20,7 +20,8 @@ import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.model.ObjectMetadata;
 import com.amazonaws.services.s3.model.PutObjectRequest;
 import com.amazonaws.services.s3.model.S3Object;
-import com.huemap.backend.common.IntegrationTest;
+import com.huemap.backend.support.IntegrationTest;
+import com.huemap.backend.support.S3MockConfig;
 
 @ActiveProfiles("test")
 @Import({S3MockConfig.class})

--- a/backend/src/test/java/com/huemap/backend/support/ControllerTest.java
+++ b/backend/src/test/java/com/huemap/backend/support/ControllerTest.java
@@ -1,0 +1,37 @@
+package com.huemap.backend.support;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
+import org.springframework.test.web.servlet.MockMvc;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.huemap.backend.common.config.RedisConfig;
+import com.huemap.backend.domain.bin.application.BinService;
+import com.huemap.backend.domain.bin.presentation.BinController;
+import com.huemap.backend.domain.report.application.ReportService;
+import com.huemap.backend.domain.report.presentation.ReportController;
+
+@Import({TestRedisConfig.class, RedisConfig.class})
+@WebMvcTest({
+    BinController.class,
+    ReportController.class
+})
+@MockBean(JpaMetamodelMappingContext.class)
+public class ControllerTest {
+
+  @Autowired
+  protected MockMvc mockMvc;
+
+  @Autowired
+  protected ObjectMapper objectMapper;
+
+  @MockBean
+  protected BinService binService;
+
+  @MockBean
+  protected ReportService reportService;
+
+}

--- a/backend/src/test/java/com/huemap/backend/support/IntegrationTest.java
+++ b/backend/src/test/java/com/huemap/backend/support/IntegrationTest.java
@@ -1,10 +1,12 @@
-package com.huemap.backend.common;
+package com.huemap.backend.support;
 
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
 
 import com.huemap.backend.infrastructure.s3.S3Uploader;
 
+@Import(TestRedisConfig.class)
 @SpringBootTest
 public class IntegrationTest {
 

--- a/backend/src/test/java/com/huemap/backend/support/RepositoryTest.java
+++ b/backend/src/test/java/com/huemap/backend/support/RepositoryTest.java
@@ -1,0 +1,21 @@
+package com.huemap.backend.support;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+
+import com.huemap.backend.common.config.RedisConfig;
+import com.huemap.backend.domain.bin.domain.BinRepository;
+import com.huemap.backend.domain.report.domain.ReportRepository;
+
+@Import({TestRedisConfig.class, RedisConfig.class})
+@DataJpaTest
+public class RepositoryTest {
+
+  @Autowired
+  protected ReportRepository reportRepository;
+
+  @Autowired
+  protected BinRepository binRepository;
+
+}

--- a/backend/src/test/java/com/huemap/backend/support/S3MockConfig.java
+++ b/backend/src/test/java/com/huemap/backend/support/S3MockConfig.java
@@ -1,4 +1,4 @@
-package com.huemap.backend.infrastructure.s3;
+package com.huemap.backend.support;
 
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Bean;

--- a/backend/src/test/java/com/huemap/backend/support/TestRedisConfig.java
+++ b/backend/src/test/java/com/huemap/backend/support/TestRedisConfig.java
@@ -1,0 +1,39 @@
+package com.huemap.backend.support;
+
+import javax.annotation.PostConstruct;
+import javax.annotation.PreDestroy;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.test.context.TestConfiguration;
+
+import lombok.extern.slf4j.Slf4j;
+import redis.embedded.RedisServer;
+
+@Slf4j
+@TestConfiguration
+public class TestRedisConfig {
+
+  private RedisServer redisServer;
+
+  public TestRedisConfig(@Value("${spring.redis.port}") int redisPort) {
+    redisServer = RedisServer.builder()
+        .port(redisPort)
+        .setting("maxmemory 128M")
+        .build();
+  }
+
+  @PostConstruct
+  public void startRedis() {
+    try {
+      redisServer.start();
+    } catch (Exception e) {
+      log.error("", e);
+    }
+  }
+
+  @PreDestroy
+  public void stopRedis() {
+    redisServer.stop();
+  }
+
+}

--- a/backend/src/test/java/com/huemap/backend/support/TestUtils.java
+++ b/backend/src/test/java/com/huemap/backend/support/TestUtils.java
@@ -1,4 +1,4 @@
-package com.huemap.backend.common;
+package com.huemap.backend.support;
 
 import java.lang.reflect.Constructor;
 

--- a/backend/src/test/resources/application.yml
+++ b/backend/src/test/resources/application.yml
@@ -12,6 +12,9 @@ spring:
         format_sql: true
         ddl-auto: create
         dialect: org.hibernate.spatial.dialect.h2geodb.GeoDBDialect
+  redis:
+    host: localhost
+    port: 16379
 
 cloud:
   aws:


### PR DESCRIPTION
* session 로그인 방식을 사용하여 유저 로그인 구현 예정
*  Redis를 통해 HttpSession을 관리하도록 하겠습니다.
* 로컬에서 애플리케이션을 실행시킬 때 redis 서버를 start 해야합니다.
* 구현이 된다면 도커내에 redis 설치 후 redis-server를 띄워야될 거 같습니다.
* http session으로 redis을 활용하니 테스트가 모두 깨지는 문제가 발생하여 embedd redis를 도입하였습니다.
* 중복을 막기 위해 레이어 별로 테스트 서포트 클래스를 생성하였습니다.